### PR TITLE
ポケモン一覧ページにおけるタイトル条件の初期状態を修正

### DIFF
--- a/app/controllers/pokemons_controller.rb
+++ b/app/controllers/pokemons_controller.rb
@@ -26,7 +26,11 @@ class PokemonsController < ApplicationController
   def index
     @pokemon_name = ''
     @pokemon_types = []
-    @pokemon_titles = {}
+    @pokemon_titles = {
+      'sword' => PokemonTitlesCriteria::NOT_CONCERN,
+      'shield' => PokemonTitlesCriteria::NOT_CONCERN
+    }
+
 
     @regional_pokedex = RegionalPokedex.find_by!(name: params[:regional_pokedex_name])
     @pokemons = @regional_pokedex.pokemons
@@ -42,6 +46,7 @@ class PokemonsController < ApplicationController
     types_criteria = PokemonTypesCriteria.new(@pokemon_types)
 
     @pokemon_titles = params[:pokemon_titles]
+    puts @pokemon_titles
     titles_criteria = PokemonTitlesCriteria.new(@pokemon_titles)
 
     criteria_list = [name_criteria, types_criteria, titles_criteria]

--- a/app/views/pokemons/_list.html.erb
+++ b/app/views/pokemons/_list.html.erb
@@ -38,7 +38,7 @@
                     type="radio"
                     name="pokemon_titles[<%= pokemon_title[:key] %>]"
                     id="pokemon-title-<%= pokemon_title[:key] %>-<%= appear[:value] %>"
-                    value="<%= appear[:value] %>"<%= @pokemon_titles.empty? || @pokemon_titles[pokemon_title[:key]] == appear[:value] ? " checked" : "" %>
+                    value="<%= appear[:value] %>"<%= @pokemon_titles[pokemon_title[:key]] == appear[:value] ? " checked" : "" %>
                   >
                   <label class="form-check-label" for="pokemon-title-<%= pokemon_title[:key] %>-<%= appear[:value] %>"><%= appear[:label] %></label>
                 </div>


### PR DESCRIPTION
ポケモン一覧ページにおいて、タイトル条件のチェックボックスの「考慮しない」にチェックが入るように修正

to close #20 